### PR TITLE
update for openlid

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
     "zstandard==0.22.0",
     "fire",
     "numpy==1.23.5",
-    "fasttext @ git+https://github.com/facebookresearch/fastText@1142dc4c4ecbc19cc16eee5cdd28472e689267e6",
+    "fasttext==0.9.3",
     "prtpy==0.8.3"
 ]
 

--- a/src/hplt_textpipes/stage3/fastertext_lid/proto_langid.py
+++ b/src/hplt_textpipes/stage3/fastertext_lid/proto_langid.py
@@ -33,7 +33,7 @@ class FastTextLangId:
         Init the FastText model.
 
         To download the model, run the following commands:
-        wget https://zenodo.org/records/15056559/files/openlid_v2_180325.bin
+        wget https://zenodo.org/records/17593102/files/openlid_v3_model.bin
 
         Expected usage (stdin jsonlines):
         python -m src.hplt_textpipes.stage2.fastertext_lid.proto_langid --model_path $MODEL_PATH < $YOUR_FILE
@@ -55,7 +55,7 @@ class FastTextLangId:
             raise TypeError(msg)
 
         self.logger.debug("Before: %s", text)
-        text = text.replace('\n', ' ').strip().lower()
+        text = text.strip().replace('\n', ' ').lower()
         text = regex.sub(SPACE_PATTERN, " ", text)
         text = regex.sub(NONWORD_REPLACE_PATTERN, "", text)
         self.logger.debug("After: %s", text)
@@ -67,7 +67,7 @@ class FastTextLangId:
 
         Example: "__label__eng_Latn" -> "eng_Latn"
         """
-        return [label.replace("__label__", "") for label in prediction[0]]
+        return [label.removeprefix("__label__") for label in prediction[0]]
 
     def _postprocess_predicted_probabilities(self, prediction: tuple) -> list[float]:
         """

--- a/src/hplt_textpipes/stage3/stage3download.sh
+++ b/src/hplt_textpipes/stage3/stage3download.sh
@@ -1,6 +1,5 @@
 DDIR=~/.cache/hplt
 mkdir -p $DDIR
 
-#wget -P $DDIR https://zenodo.org/records/15056559/files/openlid_v2_180325.bin
+wget -P $DDIR https://zenodo.org/records/17593102/files/openlid_v3_model.bin
 curl --location -o ${DDIR}/glotlid-v3.bin https://huggingface.co/cis-lmu/glotlid/resolve/main/model_v3.bin?download=true
-cp -a cp /scratch/project_465002259/eurolid/frp/model.bin ${DDIR}/openlid-v3.bin


### PR DESCRIPTION
updated FastText version, model download url. Preprocessing[ is the same as was in the training ](https://github.com/hplt-project/mtm25-langid/blob/4aaab0b648a3a741b5ab75a97f667df453e3af40/baselines/scripts/retrain_openlid/make_training_openlid.py#L6), minor changes for runtime (strip and [removeprefix](https://peps.python.org/pep-0616/) are faster than replace). 
